### PR TITLE
Pod typo, file tests, and a maybe a new file argument

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -108,6 +108,7 @@ Valid arguments are:
   log_file    - a leaf name for the file to log to with to_file
   log_path    - path in which to log to file; defaults to DISPATCHOULI_PATH
                 environment variable or, failing that, to your system's tmpdir
+  file_callbacks - alternative callbacks to modify messages logged to file
 
   log_pid     - if true, prefix all log entries with the pid; default: true
   fail_fatal  - a boolean; if true, failure to log is fatal; default: true
@@ -169,7 +170,7 @@ sub new {
         min_level => 'debug',
         filename  => $log_file,
         mode      => 'append',
-        callbacks => sub {
+        callbacks => $arg->{file_callbacks} || sub {
           # The time format returned here is subject to change. -- rjbs,
           # 2008-11-21
           return (localtime) . ' ' . {@_}->{message} . "\n"


### PR DESCRIPTION
I love this module, but everytime I use it I find myself overwriting the 'new' functionality to be able to specify my own `callbacks` argument for the file logger.
What do you think about making this customizable?

Attached is a very simple solution for doing so.

If you don't care for the option or the implementation,
feel free to use either of the first two commits (pod syntax error and basic file tests).
