### PR TITLE
Fix tests when JSON::XS is missing

### DIFF
--- a/t/file.t
+++ b/t/file.t
@@ -28,7 +28,7 @@ my $tmpdir = tempdir( TMPDIR => 1, CLEANUP => 1 );
   ok -r $log_file, 'log file with ident name';
 
   like slurp_file($log_file),
-    qr/^.+? \[$$\] point: \{\{\{("[xy]": [12](, )?){2}\}\}\}$/,
+    qr/^.+? \[$$\] point: \{\{\{("[xy]": [12](, ?)?){2}\}\}\}$/,
     'logged timestamp, pid, and hash';
 }
 


### PR DESCRIPTION
JSON::PP doesn't add a space after the comma even when space_after is set, so handle either case.
