### PR TITLE
This is my first attempt at providing the feature equivalent of caller_level in Log::Contextual.

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -224,6 +224,9 @@ sub new {
     );
   }
 
+  $self->{caller_level} = 1;
+  $self->{caller_level} = $arg->{caller_level} if exists $arg->{caller_level};
+
   $self->{dispatcher} = $log;
   $self->{prefix}     = $arg->{prefix};
   $self->{ident}      = $ident;
@@ -290,8 +293,12 @@ sub log {
     };
   }
 
-  Carp::croak $message if $arg->{fatal};
-
+  if ( $arg->{fatal} ){
+      local $Carp::CarpLevel = $Carp::CarpLevel;
+      $Carp::CarpLevel = $self->{caller_level} if $self->{caller_level};
+      $Carp::CarpLevel = $arg->{caller_level} if $arg->{caller_level};
+      Carp::croak $message if $arg->{fatal};
+  }
   return;
 }
 
@@ -313,6 +320,7 @@ sub log_fatal {
 
   local $arg->{level} = defined $arg->{level} ? $arg->{level} : 'error';
   local $arg->{fatal} = defined $arg->{fatal} ? $arg->{fatal} : 1;
+  local $arg->{caller_level} = defined $arg->{caller_level} ? $arg->{caller_level} + 1 : $self->{caller_level} + 1;
 
   $self->log($arg, @rest);
 }
@@ -336,6 +344,7 @@ sub log_debug {
   my $arg = _HASH0($rest[0]) ? shift(@rest) : {}; # for future expansion
 
   local $arg->{level} = defined $arg->{level} ? $arg->{level} : 'debug';
+  local $arg->{caller_level} = defined $arg->{caller_level} ? $arg->{caller_level} + 1 : $self->{caller_level} + 1;
 
   $self->log($arg, @rest);
 }

--- a/lib/Log/Dispatchouli/Proxy.pm
+++ b/lib/Log/Dispatchouli/Proxy.pm
@@ -34,7 +34,9 @@ sub _new {
     logger => $arg->{logger},
     debug  => $arg->{debug},
     proxy_prefix => $arg->{proxy_prefix},
+    caller_level => 1
   };
+  $guts->{caller_level} = $arg->{caller_level} if exists $arg->{caller_level};
 
   bless $guts => $class;
 }
@@ -101,6 +103,7 @@ sub log {
   return if $self->_get_local_muted and ! $arg->{fatal};
 
   local $arg->{prefix} = $self->_get_all_prefix($arg);
+  local $arg->{caller_level} = exists $arg->{caller_level} ? $arg->{caller_level} + 1 : $self->{caller_level} + 1;
 
   $self->parent->log($arg, @rest);
 }
@@ -110,6 +113,7 @@ sub log_fatal {
 
   my $arg = _HASH0($rest[0]) ? shift(@rest) : {};
   local $arg->{fatal}  = 1;
+  local $arg->{caller_level} = exists $arg->{caller_level} ? $arg->{caller_level} + 1 : $self->{caller_level} + 1;
 
   $self->log($arg, @rest);
 }
@@ -122,6 +126,7 @@ sub log_debug {
 
   my $arg = _HASH0($rest[0]) ? shift(@rest) : {};
   local $arg->{level} = 'debug';
+  local $arg->{caller_level} = exists $arg->{caller_level} ? $arg->{caller_level} + 1 : $self->{caller_level} + 1;
 
   $self->log($arg, @rest);
 }


### PR DESCRIPTION

  1. It allows `Log::Dispatchouli` to have a default caller_level of 1

  2. It allows `Log::Dispatchouli` to have the per-instance default
overridden during `->new()`

  3. It allows overriding the per-call caller level by passing the
parameter to `->log()`

  4. Indirect methods such as log_fatal and log_debug automatically
increment the caller level by 1.

Finally, it only changes `$Carp::CarpLevel` to the most useful/most
available depending on circumstances.

Granted, I have no idea what I am doing, but so far, these basic tests
give the illusion of making `log_fatal` expose a more relevant top stack
frame when called from Log::Contextual

Visible benefits to `Dist::Zilla`
----

Before this patch, calling

```perl
$self->log_fatal("reason");
```

Dies with
```text
[Bootstrap::lib] Bootstrapping lib
[Bootstrap::lib] reason
[Bootstrap::lib] reason at /home/kent/perl5/perlbrew/perls/perl-5.19.6/lib/site_perl/5.19.6/x86_64-linux/Moose/Meta/Method/Delegation.pm line 116.
```

Which is obviously not so useful.

After this patch, the same fails with:

```
[Bootstrap::lib] Bootstrapping lib
[Bootstrap::lib] reason
[Bootstrap::lib] reason at lib/Dist/Zilla/Plugin/Bootstrap/lib.pm line 161.
```

Where line 161 is in fact the line that called log_fatal()