### PR TITLE
Log::Dispatch construction optimisation: do not set a callback if log_pid == 0

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -151,9 +151,13 @@ sub new {
   my $self = bless {} => $class;
 
   my $log = Log::Dispatch->new(
-    callbacks => sub {
-      return( ($pid_prefix ? "[$$] " : '') . {@_}->{message})
-    },
+    $pid_prefix
+    ? (
+        callbacks => sub {
+	  "[$$] ". {@_}->{message}
+	},
+      )
+    : ()
   );
 
   if ($arg->{to_file}) {


### PR DESCRIPTION
The callbacks in Log::Dispatch are a hot path as they are called on every log. This is an optimisation of the callbacks set by Dispatchouli to not check if log_pid is set on every call.

The Log::Dispatchouli construction is modified to set optimized callbacks:
- if log_pid == 0, do not set a callback at all
- if log_pid == 1, set a optimized callback that just adds the "[$$] "
  prefix, without condition.
