### PR TITLE
Optimize to_file init

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -170,19 +170,21 @@ sub new {
       }
     );
 
-    my $format = $arg->{file_format} || sub {
-      # The time format returned here is subject to change. -- rjbs,
-      # 2008-11-21
-      return (localtime) . ' ' . $_[0] . "\n"
-    };
-
     $log->add(
       Log::Dispatch::File->new(
         name      => 'logfile',
         min_level => 'debug',
         filename  => $log_file,
         mode      => 'append',
-        callbacks => sub { $format->({@_}->{message}) },
+        callbacks => do {
+          if (my $format = $arg->{file_format}) {
+            sub { $format->({@_}->{message}) }
+          } else {
+            # The time format returned here is subject to change. -- rjbs,
+            # 2008-11-21
+            sub { localtime . ' ' . {@_}->{message} . "\n" }
+          }
+        },
       )
     );
   }


### PR DESCRIPTION
Two optimisations for initialisation when `to_file` is set:
- cleaner init of the default value for `log_file`
- simpler format callback when `file_format` is not set. This improves logging speed.
