### PR TITLE
Use of "localtime" without parentheses is ambiguous

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -186,7 +186,7 @@ sub new {
           } else {
             # The time format returned here is subject to change. -- rjbs,
             # 2008-11-21
-            sub { localtime . ' ' . {@_}->{message} . "\n" }
+            sub { (localtime) . ' ' . {@_}->{message} . "\n" }
           }
         },
       )


### PR DESCRIPTION
2.011 introduced a regression with commit 58d789e3015978ac746adc6525422e3702c6d77b.  The use of `localtime` without parentheses triggers a warning in older versions of Perl (e.g. [this CPAN Testers report](http://www.cpantesters.org/cpan/report/5ae4e6b8-780e-11e4-b483-cd3ee0bfc7aa)).
