### PR TITLE
Optimize Log::Dispatch callbacks

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -231,7 +231,7 @@ sub new {
         name      => "std$dest",
         min_level => 'debug',
         stderr    => ($dest eq 'err' ? 1 : 0),
-        callbacks => sub { my %arg = @_; "$arg{message}\n"; },
+        callbacks => sub { +{@_}->{message} . "\n" },
         ($quiet_fatal{"std$dest"} ? (max_level => 'info') : ()),
       ),
     );

--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -204,10 +204,8 @@ sub new {
         logopt    => 'pid',
         socket    => 'native',
         callbacks => sub {
-          my %arg = @_;
-          my $message = $arg{message};
-          $message =~ s/\n/<LF>/g;
-          return $message;
+          ( my $m = {@_}->{message} ) =~ s/\n/<LF>/g;
+          $m
         },
       ),
     );


### PR DESCRIPTION
All Log::Dispatch now use the `{@_}->{message}` trick that makes a shorter optreee.

Note that I have also sent a similar patch for the core Log::Dispatch: see autarch/Log-Dispatch#7, so its `newline` built-in option (that could be used for the Screen logs) will soon have the same optimisation.