### PR TITLE
Pass $arg->{socket} through to Log::Dispatch::Syslog, if supplied

### DIFF
--- a/lib/Log/Dispatchouli.pm
+++ b/lib/Log/Dispatchouli.pm
@@ -202,7 +202,7 @@ sub new {
         facility  => $arg->{facility},
         ident     => $ident,
         logopt    => 'pid',
-        socket    => 'native',
+        socket    => $arg->{socket} || 'native',
         callbacks => sub {
           ( my $m = {@_}->{message} ) =~ s/\n/<LF>/g;
           $m


### PR DESCRIPTION
This allows you to supply Sys::Syslog's `setlogsock()` [1] with something
other than `native`.

You might want to do this where your native log socket's receiver is
limited to 1024 bytes yet your `syslogd` daemon provides a roomier one.

[1] https://perldoc.perl.org/Sys/Syslog.html#*setlogsock()*

I have no idea how to supply a test for this change, the resulting change is several modules further down.